### PR TITLE
Fix issues on newlines and more than three forward slashes on a filepath

### DIFF
--- a/lib/wolftrans/context.rb
+++ b/lib/wolftrans/context.rb
@@ -174,6 +174,10 @@ module WolfTrans
       end
 
       def self.from_string(path)
+		if path.size > 4
+			path[3] = path[3..path.size].join("/")
+			path = path[0..3]
+		end
         if path.size != 4
           raise "invalid path specified for DB context line"
         end

--- a/lib/wolftrans/context.rb
+++ b/lib/wolftrans/context.rb
@@ -174,10 +174,10 @@ module WolfTrans
       end
 
       def self.from_string(path)
-		if path.size > 4
-			path[3] = path[3..path.size].join("/")
-			path = path[0..3]
-		end
+        if path.size > 4
+            path[3] = path[3..path.size].join("/")
+            path = path[0..3]
+        end
         if path.size != 4
           raise "invalid path specified for DB context line"
         end

--- a/lib/wolftrans/patch_text.rb
+++ b/lib/wolftrans/patch_text.rb
@@ -86,6 +86,7 @@ module WolfTrans
       pristine_translated_string = ''
 
       if File.exists? filename
+		STDOUT << filename + "\n"
         output_write = true if mode == :update
         Util.read_txt(filename).each_line.with_index do |pristine_line, index|
           # Remove comments and strip

--- a/lib/wolftrans/patch_text.rb
+++ b/lib/wolftrans/patch_text.rb
@@ -86,7 +86,7 @@ module WolfTrans
       pristine_translated_string = ''
 
       if File.exists? filename
-		STDOUT << filename + "\n"
+        STDOUT << filename + "\n"
         output_write = true if mode == :update
         Util.read_txt(filename).each_line.with_index do |pristine_line, index|
           # Remove comments and strip

--- a/lib/wolftrans/util.rb
+++ b/lib/wolftrans/util.rb
@@ -49,7 +49,8 @@ module WolfTrans
         end
       end
       # Convert Windows newlines and return
-      text.gsub(/\r\n?/, "\n")
+      # text.gsub(/\r\n?/, "\n")
+	  text.encode(universal_newline: true)
     end
   end
 end

--- a/lib/wolftrans/util.rb
+++ b/lib/wolftrans/util.rb
@@ -49,8 +49,7 @@ module WolfTrans
         end
       end
       # Convert Windows newlines and return
-      # text.gsub(/\r\n?/, "\n")
-	  text.encode(universal_newline: true)
+      text.encode(universal_newline: true)
     end
   end
 end


### PR DESCRIPTION
3 changes:
1. If a filepath has more than 3 slashes in it, allow all of the final slashes to be a part of the path name
2. don't use gsub to convert CRLF, use `universal_newline:true` https://ruby-doc.org/core-2.5.3/String.html#method-i-encode
3. Added a debug statement that prints filenames to show current status